### PR TITLE
PHP5.3 would only accept long array syntax

### DIFF
--- a/src/SoapUtils.class.php
+++ b/src/SoapUtils.class.php
@@ -128,13 +128,13 @@ class SoapUtils
         $req = new http\Client\Request("POST", $upload_url);
         $client = new http\Client;
 
-        $req->getBody()->addForm([], [
-            [
+        $req->getBody()->addForm(array(), array(
+            array(
                 "name" => "upfile",
                 "type" => "video/mpeg",
                 "file" => $file_path
-            ]
-        ]);
+            )
+        ));
 
         echo "------------------------------------\n";
         echo "Start upload. \n";


### PR DESCRIPTION
PHP5.3では配列の短縮構文をサポートしていません。